### PR TITLE
Fix bug: static plugin names are always empty [WIP] [Breaks BC]

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -56,8 +56,7 @@ func GetGlobal(name string) interface{} {
 	return plugin.globals[name]
 }
 
-func StaticPlugin(instance interface{}, interfaces []string) {
-	name := reflect.TypeOf(instance).Name()
+func StaticPlugin(name string, instance interface{}, interfaces []string) {
 	for _, interfaceName := range interfaces {
 		registerInterface(name, interfaceName)
 	}

--- a/plugins_static_test.go
+++ b/plugins_static_test.go
@@ -7,11 +7,11 @@ import (
 type TestStaticPlugin struct {
 	Run func() string
 	//Id string //Conflicts with plugins.go:184
-	
+
 }
 
 var TestStaticPluginExt struct {
-	Plugin func(string) TestStaticPlugin
+	Plugin  func(string) TestStaticPlugin
 	Plugins func() []TestStaticPlugin
 }
 
@@ -31,26 +31,25 @@ func (p StaticPlugin2) Run() string {
 	return p.Id
 }
 
-
 func Test_MultiStatic(t *testing.T) {
-        ExtensionPoint(&TestStaticPluginExt)
-        StaticPlugin("1a", &StaticPlugin1{Id: "1a"}, []string{"TestStaticPlugin"})
-        StaticPlugin("1b", &StaticPlugin1{Id: "1b"}, []string{"TestStaticPlugin"})
-        StaticPlugin("2a", &StaticPlugin2{Id: "2a"}, []string{"TestStaticPlugin"})
+	ExtensionPoint(&TestStaticPluginExt)
+	StaticPlugin("1a", &StaticPlugin1{Id: "1a"}, []string{"TestStaticPlugin"})
+	StaticPlugin("1b", &StaticPlugin1{Id: "1b"}, []string{"TestStaticPlugin"})
+	StaticPlugin("2a", &StaticPlugin2{Id: "2a"}, []string{"TestStaticPlugin"})
 
-        testPlugin1a := TestStaticPluginExt.Plugin("1a")
+	testPlugin1a := TestStaticPluginExt.Plugin("1a")
 	output := testPlugin1a.Run()
 	if output != "1a" {
 		t.Errorf("Got: \"%s\", Expected: \"%s\"", output, "1a")
 	}
 
-        testPlugin1b := TestStaticPluginExt.Plugin("1b")
+	testPlugin1b := TestStaticPluginExt.Plugin("1b")
 	output = testPlugin1b.Run()
 	if output != "1b" {
 		t.Errorf("Got: \"%s\", Expected: \"%s\"", output, "1b")
 	}
 
-        testPlugin2a := TestStaticPluginExt.Plugin("2a")
+	testPlugin2a := TestStaticPluginExt.Plugin("2a")
 	output = testPlugin2a.Run()
 	if output != "2a" {
 		t.Errorf("Got: \"%s\", Expected: \"%s\"", output, "2a")

--- a/plugins_static_test.go
+++ b/plugins_static_test.go
@@ -1,0 +1,58 @@
+package plugins
+
+import (
+	"testing"
+)
+
+type TestStaticPlugin struct {
+	Run func() string
+	//Id string //Conflicts with plugins.go:184
+	
+}
+
+var TestStaticPluginExt struct {
+	Plugin func(string) TestStaticPlugin
+	Plugins func() []TestStaticPlugin
+}
+
+type StaticPlugin1 struct {
+	Id string
+}
+
+func (p StaticPlugin1) Run() string {
+	return p.Id
+}
+
+type StaticPlugin2 struct {
+	Id string
+}
+
+func (p StaticPlugin2) Run() string {
+	return p.Id
+}
+
+
+func Test_MultiStatic(t *testing.T) {
+        ExtensionPoint(&TestStaticPluginExt)
+        StaticPlugin("1a", &StaticPlugin1{Id: "1a"}, []string{"TestStaticPlugin"})
+        StaticPlugin("1b", &StaticPlugin1{Id: "1b"}, []string{"TestStaticPlugin"})
+        StaticPlugin("2a", &StaticPlugin2{Id: "2a"}, []string{"TestStaticPlugin"})
+
+        testPlugin1a := TestStaticPluginExt.Plugin("1a")
+	output := testPlugin1a.Run()
+	if output != "1a" {
+		t.Errorf("Got: \"%s\", Expected: \"%s\"", output, "1a")
+	}
+
+        testPlugin1b := TestStaticPluginExt.Plugin("1b")
+	output = testPlugin1b.Run()
+	if output != "1b" {
+		t.Errorf("Got: \"%s\", Expected: \"%s\"", output, "1b")
+	}
+
+        testPlugin2a := TestStaticPluginExt.Plugin("2a")
+	output = testPlugin2a.Run()
+	if output != "2a" {
+		t.Errorf("Got: \"%s\", Expected: \"%s\"", output, "2a")
+	}
+}


### PR DESCRIPTION
Do not merge yet: WIP
Caution: breaks BC!

There's a bug in the function StaticPlugin where the call to Type.Name() (line 60) will always return an empty string.
This bug will make it impossible to register multiple static plugins, since the name is used as the key in the maps.

I fixed the bug by changing StaticPlugin's signature to make it receive a name for the plugin, just like LoadString works.
But this breaks BC. Other options are:
- Create a new function instead (something like NamedStaticPlugin), but this will leave StaticPlugin broken.
- Use Type.String() instead of Type.Name(), but this will make it impossible to register multiple plugin instances based on the same plugin.

Let me know how you want to proceed and I'll modify the examples and documentation and add them to this PR.

I'm just starting with Go; please let me know if I made an obvious mistake here :)